### PR TITLE
Add option to provide temporary filename for gmsh creation

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -1,7 +1,7 @@
 using GmshTools
 
 
-function meshgeo(geofile; physical=nothing, dim=2, kwargs...)
+function meshgeo(geofile; physical=nothing, dim=2, tempname=tempname(), kwargs...)
     
     io = open(geofile)
     str = read(io, String)
@@ -17,12 +17,12 @@ function meshgeo(geofile; physical=nothing, dim=2, kwargs...)
     println(str)
     # return
     
-    temp_geo = tempname()
+    temp_geo = tempname
     open(temp_geo, "w") do io
         print(io, str)
     end
 
-    temp_msh = tempname() * ".msh"
+    temp_msh = tempname * ".msh"
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.MshFileVersion",2)
     gmsh.open(temp_geo)
@@ -167,7 +167,7 @@ Create a mesh of a sphere of radius `radius` by parsing a .geo script
 
 The target edge size is `delta`.
 """
-function meshsphere(radius, delta)
+function meshsphere(radius, delta; tempname=tempname())
     s = """
 lc = $delta;
 
@@ -199,14 +199,14 @@ Ruled Surface(3)={3} In Sphere{1};
 Ruled Surface(4)={4} In Sphere{1};
 """
 
-    fn = tempname()
+    fn = tempname
     io = open(fn, "w")
     try
         print(io, s)
     finally
         close(io)
     end
-    fno = tempname() * ".msh"
+    fno = tempname * ".msh"
 
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.MshFileVersion",2)
@@ -229,7 +229,7 @@ meshsphere(;radius, h) = meshsphere(radius, h)
 """
 not working yet
 """
-function tetmeshsphere(radius,delta)
+function tetmeshsphere(radius,delta; tempname=tempname())
     s = """
     lc = $delta;
 
@@ -277,7 +277,7 @@ function tetmeshsphere(radius,delta)
     Physical Volume(1) = {1};
     """
 
-    fn = tempname()
+    fn = tempname
     io = open(fn, "w")
     try
         print(io, s)
@@ -285,7 +285,7 @@ function tetmeshsphere(radius,delta)
         close(io)
     end
 
-    fno = tempname() * ".msh"
+    fno = tempname * ".msh"
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.MshFileVersion",2)
     gmsh.open(fn)
@@ -303,7 +303,7 @@ end
 
 
 
-function meshball(;radius, h)
+function meshball(;radius, h, tempname=tempname())
 
     fn = joinpath(@__DIR__,"geos/structured_sphere.geo")
     io = open(fn)
@@ -313,12 +313,12 @@ function meshball(;radius, h)
     str = replace(str, "lc = 1.0;" => "lc = $h;")
     str = replace(str, "r = 1.0;" => "r = $radius;")
 
-    temp_geo = tempname()
+    temp_geo = tempname
     open(temp_geo, "w") do io
         print(io, str)
     end
 
-    temp_msh = tempname() * ".msh"
+    temp_msh = tempname * ".msh"
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.MshFileVersion",2)
     gmsh.open(temp_geo)
@@ -335,7 +335,7 @@ function meshball(;radius, h)
 end
 
 
-function meshcylinder(;radius, height, h)
+function meshcylinder(;radius, height, h, tempname=tempname())
 
     fn = joinpath(@__DIR__,"geos/cylinder3.geo")
     io = open(fn)
@@ -346,12 +346,12 @@ function meshcylinder(;radius, height, h)
     str = replace(str, "z = 1.0;" => "z = $height;")
     str = replace(str, "h = 1.0;" => "h = $h;")
 
-    temp_geo = tempname()
+    temp_geo = tempname
     open(temp_geo, "w") do io
         print(io, str)
     end
 
-    temp_msh = tempname() * ".msh"
+    temp_msh = tempname * ".msh"
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.MshFileVersion",2)
     gmsh.open(temp_geo)
@@ -379,7 +379,7 @@ physical => in {"TopPlate", "BottomPlate", "SidePlates", "OpenBox"} extracts and
 returns only the specified part of the cuboid
 
 """
-function meshcuboid(width, height, length, delta;physical="ClosedBox")
+function meshcuboid(width, height, length, delta;physical="ClosedBox", tempname=tempname())
     s =
 """
 lc = $delta;
@@ -432,7 +432,7 @@ Volume(1)={1};
 
 """
 
-    fn = tempname()
+    fn = tempname
     io = open(fn, "w")
     try
         print(io, s)
@@ -441,7 +441,7 @@ Volume(1)={1};
     end
 
     # feed the file to gmsh
-    fno = tempname() * ".msh"
+    fno = tempname * ".msh"
 
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.MshFileVersion",2)
@@ -464,7 +464,7 @@ end
     meshrectangle_unstructured(width, height, delta)
 	Meshes unstructured rectangle (Delaunay Triangulation)
 """
-function meshrectangle_unstructured(width, height, delta)
+function meshrectangle_unstructured(width, height, delta; tempname=tempname())
     s =
 		"""
 		lc = $delta;
@@ -484,7 +484,7 @@ function meshrectangle_unstructured(width, height, delta)
 		Plane Surface(5)={5};
 		"""
 
-    fn = tempname()
+    fn = tempname
     io = open(fn, "w")
     try
         print(io, s)
@@ -493,7 +493,7 @@ function meshrectangle_unstructured(width, height, delta)
     end
 
     # feed the file to gmsh
-    fno = tempname() * ".msh"
+    fno = tempname * ".msh"
 
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.MshFileVersion",2)


### PR DESCRIPTION
CompSciences meshes comes with functions that generate and load
meshes for certain geometries (e.g., meshcuboid etc) by generating
a temporary .geo file (and by gmsh generating a temporary .msh file)

The filenames of the temporary files a generated by invoking the Julia
function tempname(). Under Linux per default the file paths begin with
/tmp/

This causes problems on machines, where the user has not write rights
to /tmp  (e.g., on a computational cluster).

This commits adds a keyword argument tempname that allows to specify
an individual filename.