### PR TITLE
decoupling normal triangle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 GmshTools = "82e2f556-b1bd-5f1a-9576-f93c0da5f0ee"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 GmshTools = "82e2f556-b1bd-5f1a-9576-f93c0da5f0ee"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 

--- a/src/charts.jl
+++ b/src/charts.jl
@@ -12,9 +12,14 @@ struct Simplex{U,D,C,N,T}
     normals::SVector{C,SVector{U,T}}
     volume::T
 end
-
+normal(t::Simplex{3,2,1,3,<:Number}) = t.normals[1]
 dimtype(splx::Simplex{U,D}) where {U,D} = Val{D}
 
+function permute_vertices(s::Simplex{3,2,1,3,<:Number},permutation::Union{Vector{3,Int},SVector{3,Int}})
+vert = vertices(s)[permutation]
+simp = simplex(vert)
+Simplex(vertics(simp),tangents(simp),s.normals,volume(simp))
+end
 
 """
     coordtype(simplex)

--- a/src/charts.jl
+++ b/src/charts.jl
@@ -22,10 +22,12 @@ Simplex(simp.vertices,simp.tangents,s.normals,simp.volume)
 end
 flip_normal(t::Simplex{3,2,1,3,<:Number}) = Simplex(t.vertices,t.tangents,-t.normals,t.volume)
 function flip_normal(t::Simplex{3,2,1,3,<:Number},sign::Int)
-sign == 1 && return t
-return flip_normal(t)
-end
+    sign == 1 && return t
+    return flip_normal(t)
+    end
 export flip_normal
+
+tangents(s::Simplex{3,2,1,3,<:Number},i) = s.tangents[i]
 """
     coordtype(simplex)
 

--- a/src/charts.jl
+++ b/src/charts.jl
@@ -14,11 +14,17 @@ struct Simplex{U,D,C,N,T}
 end
 normal(t::Simplex{3,2,1,3,<:Number}) = t.normals[1]
 dimtype(splx::Simplex{U,D}) where {U,D} = Val{D}
+"""
+    permute_simplex(simplex,permutation)
 
+Permutation is a Vector v which sets the v[i]-th vertex at the i-th place.
+
+Return Simplex with permuted vertices list, tangents are recalculated, normal is kept the same
+"""
 function permute_vertices(s::Simplex{3,2,1,3,T},permutation::Union{Vector{P},SVector{P}}) where {T,P}
-vert = SVector{3,SVector{3,T}}(s.vertices[permutation])
-simp = simplex(vert)
-Simplex(simp.vertices,simp.tangents,s.normals,simp.volume)
+    vert = SVector{3,SVector{3,T}}(s.vertices[permutation])
+    simp = simplex(vert)
+    Simplex(simp.vertices,simp.tangents,s.normals,simp.volume)
 end
 flip_normal(t::Simplex{3,2,1,3,<:Number}) = Simplex(t.vertices,t.tangents,-t.normals,t.volume)
 function flip_normal(t::Simplex{3,2,1,3,<:Number},sign::Int)
@@ -138,7 +144,7 @@ simplex(vertices...) = simplex(SVector((vertices...,)))
     :(simplex(SVector{$D1,$P}($xp)))
 end
 
-normal(s::Simplex{3,2,1,3,T}) where {T} = normalize(cross(s[1]-s[3],s[2]-s[3]))
+# normal(s::Simplex{3,2,1,3,T}) where {T} = normalize(cross(s[1]-s[3],s[2]-s[3]))
 
 
 function _normals(tangents, ::Type{Val{1}})

--- a/src/charts.jl
+++ b/src/charts.jl
@@ -20,6 +20,7 @@ vert = SVector{3,SVector{3,T}}(s.vertices[permutation])
 simp = simplex(vert)
 Simplex(simp.vertices,simp.tangents,s.normals,simp.volume)
 end
+flip_normal(t::Simplex{3,2,1,3,<:Number}) = Simplex(t.vertices,t.tangents,-t.normals,t.volume)
 
 """
     coordtype(simplex)

--- a/src/charts.jl
+++ b/src/charts.jl
@@ -26,7 +26,19 @@ function permute_vertices(s::Simplex{3,2,1,3,T},permutation::Union{Vector{P},SVe
     simp = simplex(vert)
     Simplex(simp.vertices,simp.tangents,s.normals,simp.volume)
 end
+
+"""
+    flip_normal(simplex)
+
+Flips the normal of the simplex. Only on triangles embedded in 3D space
+"""
 flip_normal(t::Simplex{3,2,1,3,<:Number}) = Simplex(t.vertices,t.tangents,-t.normals,t.volume)
+
+"""
+    flip_normal(simplex, sign)
+
+Flips the normal of the simplex if sign is -1. Only on triangles embedded in 3D space
+"""
 function flip_normal(t::Simplex{3,2,1,3,<:Number},sign::Int)
     sign == 1 && return t
     return flip_normal(t)
@@ -360,5 +372,11 @@ Returns a matrix whose columns are the tangents of the simplex `splx`.
 tangents(splx::Simplex) = hcat((splx.tangents)...)
 
 vertices(splx::Simplex) = hcat((splx.vertices)...)
+
+"""
+    verticeslist(simplex)
+
+Returns the vertices as a list.
+"""
 verticeslist(splx::Simplex) = splx.vertices
 export verticeslist

--- a/src/charts.jl
+++ b/src/charts.jl
@@ -15,10 +15,10 @@ end
 normal(t::Simplex{3,2,1,3,<:Number}) = t.normals[1]
 dimtype(splx::Simplex{U,D}) where {U,D} = Val{D}
 
-function permute_vertices(s::Simplex{3,2,1,3,<:Number},permutation::Union{Vector{3,Int},SVector{3,Int}})
-vert = vertices(s)[permutation]
+function permute_vertices(s::Simplex{3,2,1,3,T},permutation::Union{Vector{P},SVector{P}}) where {T,P}
+vert = SVector{3,SVector{3,T}}(s.vertices[permutation])
 simp = simplex(vert)
-Simplex(vertics(simp),tangents(simp),s.normals,volume(simp))
+Simplex(simp.vertices,simp.tangents,s.normals,simp.volume)
 end
 
 """

--- a/src/charts.jl
+++ b/src/charts.jl
@@ -21,7 +21,11 @@ simp = simplex(vert)
 Simplex(simp.vertices,simp.tangents,s.normals,simp.volume)
 end
 flip_normal(t::Simplex{3,2,1,3,<:Number}) = Simplex(t.vertices,t.tangents,-t.normals,t.volume)
-
+function flip_normal(t::Simplex{3,2,1,3,<:Number},sign::Int)
+sign == 1 && return t
+return flip_normal(t)
+end
+export flip_normal
 """
     coordtype(simplex)
 
@@ -348,3 +352,5 @@ Returns a matrix whose columns are the tangents of the simplex `splx`.
 tangents(splx::Simplex) = hcat((splx.tangents)...)
 
 vertices(splx::Simplex) = hcat((splx.vertices)...)
+verticeslist(splx::Simplex) = splx.vertices
+export verticeslist

--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -34,9 +34,10 @@ end
 
 The output inherits the orientation from the first operand
 """
-function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3}) where {U,C}
+function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3};tol=eps()) where {U,C}
   pq = sutherlandhodgman(p1.vertices, p2.vertices)
   nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
+  nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]
   signs = Int.(sign.(dot.(normal.(nonoriented_simplexes,Ref(normal(p1))))))
   flip_normal.(nonoriented_simplexes,signs)
 end
@@ -47,8 +48,21 @@ function intersection(p1::Simplex{U,3,C,4}, p2::Simplex{U,3,C,4}) where {U,C}
   volume(p1) <= volume(p2) ? [p1] : [p2]
 end
 
+function intersection2(p1::Simplex, p2::Simplex) where {U,C}
+    a = intersection(p1,p2)
+    return [(i,i) for i in a]
+end
 
-
+function intersection2(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3}; tol=eps()) where {U,C}
+    pq = sutherlandhodgman(p1.vertices, p2.vertices)
+    nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
+    nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]
+    signs1 = Int.(sign.(dot.(normal.(nonoriented_simplexes),Ref(normal(p1)))))
+    
+    signs2 = Int.(sign.(dot.(normal.(nonoriented_simplexes),Ref(normal(p2)))))
+    return [(flip_normal(s,signs1[i]),flip_normal(s,signs2[i])) for (i,s) in enumerate(nonoriented_simplexes)]
+end
+export intersection2
 """
     intersectline(a,b,p,q)
 

--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -38,7 +38,7 @@ function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3};tol=eps()) wher
   pq = sutherlandhodgman(p1.vertices, p2.vertices)
   nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
   nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]
-  signs = Int.(sign.(dot.(normal.(nonoriented_simplexes,Ref(normal(p1))))))
+  signs = Int.(sign.(dot.(normal.(nonoriented_simplexes),Ref(normal(p1)))))
   flip_normal.(nonoriented_simplexes,signs)
 end
 

--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -36,7 +36,9 @@ The output inherits the orientation from the first operand
 """
 function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3}) where {U,C}
   pq = sutherlandhodgman(p1.vertices, p2.vertices)
-  [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
+  nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
+  signs = Int.(sign.(dot.(normal.(nonoriented_simplexes,Ref(normal(p1))))))
+  flip_normal.(nonoriented_simplexes,signs)
 end
 
 

--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -38,7 +38,7 @@ function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3}) where {U,C}
   pq = sutherlandhodgman(p1.vertices, p2.vertices)
   return [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
 end
-function intersection(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3};tol=eps()) where {U,C}
+function intersection(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3};tol=eps()) 
     pq = sutherlandhodgman(p1.vertices, p2.vertices)
     nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
     nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]
@@ -52,12 +52,12 @@ function intersection(p1::Simplex{U,3,C,4}, p2::Simplex{U,3,C,4}) where {U,C}
   volume(p1) <= volume(p2) ? [p1] : [p2]
 end
 
-function intersection2(p1::Simplex, p2::Simplex) where {U,C}
+function intersection2(p1::Simplex, p2::Simplex)
     a = intersection(p1,p2)
     return [(i,i) for i in a]
 end
 
-function intersection2(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3}; tol=eps()) where {U,C}
+function intersection2(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3}; tol=eps())
     pq = sutherlandhodgman(p1.vertices, p2.vertices)
     nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
     nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]

--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -34,13 +34,17 @@ end
 
 The output inherits the orientation from the first operand
 """
-function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3};tol=eps()) where {U,C}
+function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3}) where {U,C}
   pq = sutherlandhodgman(p1.vertices, p2.vertices)
-  nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
-  nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]
-  signs = Int.(sign.(dot.(normal.(nonoriented_simplexes),Ref(normal(p1)))))
-  flip_normal.(nonoriented_simplexes,signs)
+  return [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
 end
+function intersection(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3};tol=eps()) where {U,C}
+    pq = sutherlandhodgman(p1.vertices, p2.vertices)
+    nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
+    nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]
+    signs = Int.(sign.(dot.(normal.(nonoriented_simplexes),Ref(normal(p1)))))
+    flip_normal.(nonoriented_simplexes,signs)
+  end
 
 
 function intersection(p1::Simplex{U,3,C,4}, p2::Simplex{U,3,C,4}) where {U,C}
@@ -53,7 +57,7 @@ function intersection2(p1::Simplex, p2::Simplex) where {U,C}
     return [(i,i) for i in a]
 end
 
-function intersection2(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3}; tol=eps()) where {U,C}
+function intersection2(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3}; tol=eps()) where {U,C}
     pq = sutherlandhodgman(p1.vertices, p2.vertices)
     nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
     nonoriented_simplexes = nonoriented_simplexes[volume.(nonoriented_simplexes).>tol]

--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -38,6 +38,7 @@ function intersection(p1::Simplex{U,2,C,3}, p2::Simplex{U,2,C,3}) where {U,C}
   pq = sutherlandhodgman(p1.vertices, p2.vertices)
   return [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
 end
+
 function intersection(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3};tol=eps()) 
     pq = sutherlandhodgman(p1.vertices, p2.vertices)
     nonoriented_simplexes = [ simplex(pq[1], pq[i], pq[i+1]) for i in 2:length(pq)-1 ]
@@ -52,6 +53,12 @@ function intersection(p1::Simplex{U,3,C,4}, p2::Simplex{U,3,C,4}) where {U,C}
   volume(p1) <= volume(p2) ? [p1] : [p2]
 end
 
+"""
+    intersection2(triangleA, triangleB)
+
+returns intersection in which the first operand inhirits orientation from first argument
+and second argument inhirits orientation of second argument.
+"""
 function intersection2(p1::Simplex, p2::Simplex)
     a = intersection(p1,p2)
     return [(i,i) for i in a]
@@ -67,6 +74,7 @@ function intersection2(p1::Simplex{3,2,1,3}, p2::Simplex{3,2,1,3}; tol=eps())
     return [(flip_normal(s,signs1[i]),flip_normal(s,signs2[i])) for (i,s) in enumerate(nonoriented_simplexes)]
 end
 export intersection2
+
 """
     intersectline(a,b,p,q)
 

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -139,7 +139,7 @@ or vertices not appearing in any cell. In other words the following is not neces
     numvertices(mesh) == numcells(skeleton(mesh,0))
 ```
 """
-numvertices(m::Mesh) = length(m.vertices)
+numvertices(m::Mesh) = length(vertices(m))
 
 
 
@@ -148,7 +148,7 @@ numvertices(m::Mesh) = length(m.vertices)
 
 Returns the number of cells in the mesh.
 """
-numcells(m::AbstractMesh) = length(m.faces)
+numcells(m::AbstractMesh) = length(cells(m))
 
 
 

--- a/src/neighborhood.jl
+++ b/src/neighborhood.jl
@@ -26,7 +26,7 @@ function parametric(mp::MeshPointNM)
     mp.bary
 end
 
-chart(nbd::MeshPointNM) = mp.patch
+chart(nbd::MeshPointNM) = nbd.patch
 
 "Return the barycentric coordinates of `mp`"
 barycentric(mp::MeshPointNM) = SVector(mp.bary[1], mp.bary[2], 1-mp.bary[1]-mp.bary[2])

--- a/src/neighborhood.jl
+++ b/src/neighborhood.jl
@@ -80,3 +80,15 @@ to parameter `(1/(D+1), 1/(D+1), ...)` where `D` is the simplex dimension.
     uv = ones(T,D)/(D+1)
     :(neighborhood(p, $uv))
 end
+
+function permute_barycentric(perm,bary::Tuple{T,T}) where {T}
+    last_coef = 1-sum(bary)
+    total_bary = SVector{3,T}([bary[1],bary[2],last_coef])
+    return Tuple{T,T}(total_bary[perm][1:end-1])
+end
+function permute_barycentric(perm,bary::Tuple{T,T,T}) where {T}
+    last_coef = 1-sum(bary)
+    total_bary = SVector{4,T}([bary[1],bary[2],bary[3],last_coef])
+    return Tuple{T,T,T}(total_bary[perm][1:end-1])
+end
+export permute_barycentric

--- a/src/neighborhood.jl
+++ b/src/neighborhood.jl
@@ -81,14 +81,14 @@ to parameter `(1/(D+1), 1/(D+1), ...)` where `D` is the simplex dimension.
     :(neighborhood(p, $uv))
 end
 
-function permute_barycentric(perm,bary::Tuple{T,T}) where {T}
-    last_coef = 1-sum(bary)
-    total_bary = SVector{3,T}([bary[1],bary[2],last_coef])
-    return Tuple{T,T}(total_bary[perm][1:end-1])
-end
-function permute_barycentric(perm,bary::Tuple{T,T,T}) where {T}
-    last_coef = 1-sum(bary)
-    total_bary = SVector{4,T}([bary[1],bary[2],bary[3],last_coef])
-    return Tuple{T,T,T}(total_bary[perm][1:end-1])
-end
-export permute_barycentric
+# function permute_barycentric(perm,bary::Tuple{T,T}) where {T}
+#     last_coef = 1-sum(bary)
+#     total_bary = SVector{3,T}([bary[1],bary[2],last_coef])
+#     return Tuple{T,T}(total_bary[perm][1:end-1])
+# end
+# function permute_barycentric(perm,bary::Tuple{T,T,T}) where {T}
+#     last_coef = 1-sum(bary)
+#     total_bary = SVector{4,T}([bary[1],bary[2],bary[3],last_coef])
+#     return Tuple{T,T,T}(total_bary[perm][1:end-1])
+# end
+# export permute_barycentric

--- a/src/neighborhood.jl
+++ b/src/neighborhood.jl
@@ -81,14 +81,3 @@ to parameter `(1/(D+1), 1/(D+1), ...)` where `D` is the simplex dimension.
     :(neighborhood(p, $uv))
 end
 
-# function permute_barycentric(perm,bary::Tuple{T,T}) where {T}
-#     last_coef = 1-sum(bary)
-#     total_bary = SVector{3,T}([bary[1],bary[2],last_coef])
-#     return Tuple{T,T}(total_bary[perm][1:end-1])
-# end
-# function permute_barycentric(perm,bary::Tuple{T,T,T}) where {T}
-#     last_coef = 1-sum(bary)
-#     total_bary = SVector{4,T}([bary[1],bary[2],bary[3],last_coef])
-#     return Tuple{T,T,T}(total_bary[perm][1:end-1])
-# end
-# export permute_barycentric

--- a/src/quadpoints.jl
+++ b/src/quadpoints.jl
@@ -80,7 +80,6 @@ this method used `quadpoints(chart, rule)` to retrieve the points and weights fo
 a certain quadrature rule over `chart`.
 """
 function quadpoints(f, charts, rules)
-    println(typeof(charts))
     pw = quadpoints(charts[1], rules[1])
     P = typeof(pw[1][1])
     W = typeof(pw[1][2])

--- a/src/quadpoints.jl
+++ b/src/quadpoints.jl
@@ -80,7 +80,7 @@ this method used `quadpoints(chart, rule)` to retrieve the points and weights fo
 a certain quadrature rule over `chart`.
 """
 function quadpoints(f, charts, rules)
-
+    println(typeof(charts))
     pw = quadpoints(charts[1], rules[1])
     P = typeof(pw[1][1])
     W = typeof(pw[1][2])

--- a/src/subd_chart.jl
+++ b/src/subd_chart.jl
@@ -30,3 +30,4 @@ function getelementVertices(chart::subd_chart{T}) where {T}
     verticecoords3[3] = verticescoords[chart.N-6]
     return verticecoords3
 end
+verticeslist(chart::subd_chart) = chart.vertices

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ include("test_sh_intersection.jl")
 include("test_isinside.jl")
 include("test_jctweld.jl")
 include("test_isinclosure.jl")
+include("test_permute_vertices.jl")
 
 include("test_trgauss.jl")
 include("test_chartquad.jl")

--- a/test/test_permute_vertices.jl
+++ b/test/test_permute_vertices.jl
@@ -1,0 +1,34 @@
+using CompScienceMeshes
+using Test
+
+splx = simplex(
+    point(0,0,0),
+    point(1,0,0),
+    point(0,1,0)
+);
+
+@test normal(splx) ≈ point(0,0,1)
+
+splx1 = CompScienceMeshes.permute_vertices(splx, [2,1,3])
+@test normal(splx1) ≈ point(0,0,1)
+
+splx2 = CompScienceMeshes.flip_normal(splx)
+@test normal(splx2) ≈ point(0,0,-1)
+
+for i in 1:2
+    @test CompScienceMeshes.tangents(splx2,i) ≈ CompScienceMeshes.tangents(splx,i)
+end
+
+splx3 = simplex(
+    point(1,0.5,0),
+    point(-1,0.5,0),
+    point(-1,2.5,0)
+)
+
+isct = CompScienceMeshes.intersection2(splx, splx3)
+@test length(isct) == 1
+
+splx4, splx5 = isct[1]
+@test volume(splx4) ≈ volume(splx5)
+@test normal(splx4) ≈ -normal(splx5)
+


### PR DESCRIPTION
- Normal on triangle embedded in 3D space decoupled form the cross product of the tangents.

- Possibility added to obtain the vertices in a list with verticeslist() function.

-Intersection inhirits orientation of first operand for these decoupled form.

-Intersection 2 gives first argument in orientation of first triangle and second argument in orientation of second triangle.
