### PR TITLE
Type instability of AbstractMesh

### DIFF
--- a/src/submesh.jl
+++ b/src/submesh.jl
@@ -41,8 +41,8 @@ function submesh(sm::Mesh, bm::Mesh)
 end
 
 
-mutable struct SubMesh{U,D1,T} <: AbstractMesh{U,D1,T}
-    supermesh::AbstractMesh{U,D1,T}
+mutable struct SubMesh{U,D1,T,S<:AbstractMesh{U,D1,T}} <: AbstractMesh{U,D1,T}
+    supermesh::S
     sub2sup::Vector{Int}
     sup2sub::Vector{Int}
     # cells::Vector{SVector{D1,Int}}

--- a/src/weld.jl
+++ b/src/weld.jl
@@ -190,7 +190,7 @@ function weld(G1::SComplex2D, G2::SComplex2D; seam)
         vcat(G1.faces, Faces2))
 end
 
-@generated function map_ids(c::SimplexGraph{N}, idmap) where {N,T}
+@generated function map_ids(c::SimplexGraph{N}, idmap) where {N}
     xp = :(SimplexGraph())
     for i in 1:N
         push!(xp.args, :(idmap[c[$i]]))


### PR DESCRIPTION
Restore type stability for SubMesh by storing the concrete supermesh type and removed unused type parameter. 