### PR TITLE
correct typo in cone function

### DIFF
--- a/ext/PlotlyBaseExt.jl
+++ b/ext/PlotlyBaseExt.jl
@@ -76,7 +76,7 @@ end
 
 function CompScienceMeshes.normals(mesh; kwargs...)
     nrmls = [normal(chart(mesh,cell)) for cell in mesh]
-    return PlotlyBase.cones(mesh, nrmls; kwargs...)
+    return PlotlyBase.cone(mesh, nrmls; kwargs...)
 end
 
 function CompScienceMeshes.wireframe(edges; width=1, color="rgb(0,0,0)")


### PR DESCRIPTION
There was a typo in PlotlyBase.cone function (with s at the end), which leads to error when using normals. Please merge.